### PR TITLE
Migrate RMS name to Fiuu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {   
-    "name": "razermerchantservices/payment",
+    "name": "fiuu/payment",
     "type": "library",
-    "description": "A PHP library for Razer Merchant Services payment gateway",
-    "keywords": ["payment","razer","razermerchantservices"],
-    "homepage": "https://merchant.razer.com/",
+    "description": "A PHP library for Fiuu payment gateway",
+    "keywords": ["payment","razer","razermerchantservices","fiuu"],
+    "homepage": "https://fiuu.com/",
     "license": "MIT",
     "authors": [
         {
@@ -17,12 +17,12 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/RazerMS/SDK-RazerMS_PHP.git"
+            "url": "https://github.com/FiuuPayment/SDK-RazerMS_PHP.git"
         }
     ],
     "autoload": {
         "psr-4": {
-            "RazerMerchantServices\\": "src/lib"
+            "Fiuu\\": "src/lib"
         }
     },
     "minimum-stability": "dev",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,10 +16,10 @@
   </testsuites>
 
   <php>
-    <env name="RMS_MERCHANT_ID" value="SB_sandbox"/>
-    <env name="RMS_VERIFY_KEY" value="--replaceme--"/>
-    <env name="RMS_SECRET_KEY" value="--replaceme---"/>
-    <env name="RMS_ENVIRONMENT" value="sandbox"/>
+    <env name="FIUU_MERCHANT_ID" value="SB_sandbox"/>
+    <env name="FIUU_VERIFY_KEY" value="--replaceme--"/>
+    <env name="FIUU_SECRET_KEY" value="--replaceme---"/>
+    <env name="FIUU_ENVIRONMENT" value="sandbox"/>
     <env name="DEBUG" value="false"/>
   </php>
 </phpunit>

--- a/src/example/laravel/index.php
+++ b/src/example/laravel/index.php
@@ -1,5 +1,5 @@
 <?php
-use RazerMerchantServices\Payment;
+use Fiuu\Payment;
 
 class PaymentController extends Controller
 {
@@ -7,14 +7,14 @@ class PaymentController extends Controller
     {   
         $orderid = '12345';
         $amount = '1.10';
-        $bill_name = 'RazerMS PHP';
+        $bill_name = 'Fiuu PHP';
         $bill_email = 'test@gmail.com';
         $bill_mobile = '0123456789';
 
-        $rms = new Payment(env('RMS_MERCHANT_ID'), env('RMS_VERIFY_KEY'), env('RMS_SECRET_KEY'), env('RMS_ENVIRONMENT'));
+        $fiuu = new Payment(env('FIUU_MERCHANT_ID'), env('FIUU_VERIFY_KEY'), env('FIUU_SECRET_KEY'), env('FIUU_ENVIRONMENT'));
         
         // Optional variable to pass in getPaymentUrl - $bill_desc, $channel, $currency, $returnUrl, $callbackurl, $cancelurl
-        $paymentUrl = $rms->getPaymentUrl($orderid, $amount, $bill_name, $bill_email, $bill_mobile);
+        $paymentUrl = $fiuu->getPaymentUrl($orderid, $amount, $bill_name, $bill_email, $bill_mobile);
     
         return redirect($paymentUrl);
     }
@@ -35,9 +35,9 @@ class PaymentController extends Controller
     
     public function notification(Request $request)
     {   
-        $rms = new Payment(env('RMS_MERCHANT_ID'), env('RMS_VERIFY_KEY'), env('RMS_SECRET_KEY'), env('RMS_ENVIRONMENT'));
+        $fiuu = new Payment(env('FIUU_MERCHANT_ID'), env('FIUU_VERIFY_KEY'), env('FIUU_SECRET_KEY'), env('FIUU_ENVIRONMENT'));
         $key = md5($request->tranID.$request->orderid.$request->status.$request->domain.$request->amount.$request->currency);
-        $isPaymentValid = $rms->verifySignature($request->paydate, $request->domain, $key, $request->appcode, $request->skey);
+        $isPaymentValid = $fiuu->verifySignature($request->paydate, $request->domain, $key, $request->appcode, $request->skey);
     
         if ($isPaymentValid) {
             // Payment is valid, update order status
@@ -48,9 +48,9 @@ class PaymentController extends Controller
 
     public function callback(Request $request)
     {   
-        $rms = new Payment(env('RMS_MERCHANT_ID'), env('RMS_VERIFY_KEY'), env('RMS_SECRET_KEY'), env('RMS_ENVIRONMENT'));
+        $fiuu = new Payment(env('FIUU_MERCHANT_ID'), env('FIUU_VERIFY_KEY'), env('FIUU_SECRET_KEY'), env('FIUU_ENVIRONMENT'));
         $key = md5($request->tranID.$request->orderid.$request->status.$request->domain.$request->amount.$request->currency);
-        $isPaymentValid = $rms->verifySignature($request->paydate, $request->domain, $key, $request->appcode, $request->skey);
+        $isPaymentValid = $fiuu->verifySignature($request->paydate, $request->domain, $key, $request->appcode, $request->skey);
     
         if ($isPaymentValid) {
             // Payment is valid, update defer order status
@@ -61,9 +61,9 @@ class PaymentController extends Controller
 
     public function return(Request $request)
     {   
-        $rms = new Payment(env('RMS_MERCHANT_ID'), env('RMS_VERIFY_KEY'), env('RMS_SECRET_KEY'), env('RMS_ENVIRONMENT'));
+        $fiuu = new Payment(env('FIUU_MERCHANT_ID'), env('FIUU_VERIFY_KEY'), env('FIUU_SECRET_KEY'), env('FIUU_ENVIRONMENT'));
         $key = md5($request->tranID.$request->orderid.$request->status.$request->domain.$request->amount.$request->currency);
-        $isPaymentValid = $rms->verifySignature($request->paydate, $request->domain, $key, $request->appcode, $request->skey);
+        $isPaymentValid = $fiuu->verifySignature($request->paydate, $request->domain, $key, $request->appcode, $request->skey);
 
         if ($isPaymentValid) {
             // Payment is valid, redirect to result page

--- a/src/lib/Payment.php
+++ b/src/lib/Payment.php
@@ -1,5 +1,5 @@
 <?php
-namespace RazerMerchantServices;
+namespace Fiuu;
 
 class Payment
 {
@@ -15,7 +15,7 @@ class Payment
         $this->verifyKey = $verifyKey;
         $this->secretKey = $secretKey;
         $this->environment = $environment;
-        $this->baseUrl = ($environment === 'sandbox') ? 'https://sandbox.merchant.razer.com/RMS/pay/'.$merchantId : 'https://pay.merchant.razer.com/RMS/pay/'.$merchantId;
+        $this->baseUrl = ($environment === 'sandbox') ? 'https://sandbox-payment.fiuu.com/RMS/pay/'.$merchantId : 'https://pay.fiuu.com/RMS/pay/'.$merchantId;
     }
 
     public function getPaymentUrl($orderid, $amount, $bill_name, $bill_email, $bill_mobile, $bill_desc = 'RMS PHP Library', $channel = null, $currency = null, $returnUrl = null, $callbackurl = null, $cancelurl = null)

--- a/src/tests/PackageTest.php
+++ b/src/tests/PackageTest.php
@@ -19,9 +19,9 @@ final class PackageTest extends TestCase
      */
     public function testCanInstantateBaseClass(): void
     {
-        $rms = new FiuuPayment(null, null, null, null);
+        $fiuu = new FiuuPayment(null, null, null, null);
 
-        $this->assertNotNull($rms);
-        $this->assertEquals(get_class($rms), FiuuPayment::class);
+        $this->assertNotNull($fiuu);
+        $this->assertEquals(get_class($fiuu), FiuuPayment::class);
     }
 }

--- a/src/tests/PackageTest.php
+++ b/src/tests/PackageTest.php
@@ -3,14 +3,14 @@
 require_once(__DIR__."/../support/helpers.php");
 
 use PHPUnit\Framework\TestCase;
-use RazerMerchantServices\Payment as RmsPayment;
+use Fiuu\Payment as FiuuPayment;
 
 final class PackageTest extends TestCase
 {
     public function testCanDiscoverThisPackage(): void
     {
         $this->assertTrue(
-            class_exists(RmsPayment::class)
+            class_exists(FiuuPayment::class)
         );
     }
 
@@ -19,9 +19,9 @@ final class PackageTest extends TestCase
      */
     public function testCanInstantateBaseClass(): void
     {
-        $rms = new RmsPayment(null, null, null, null);
+        $rms = new FiuuPayment(null, null, null, null);
 
         $this->assertNotNull($rms);
-        $this->assertEquals(get_class($rms), RmsPayment::class);
+        $this->assertEquals(get_class($rms), FiuuPayment::class);
     }
 }

--- a/src/tests/PaymentTest.php
+++ b/src/tests/PaymentTest.php
@@ -60,7 +60,7 @@ final class PaymentTest extends TestCase
         $this->assertStringStartsWith("https://", $url);
 
         // check domain must be pointing to correct endpoint
-        if (env("RMS_ENVIRONMENT") == "sandbox") {
+        if (env("FIUU_ENVIRONMENT") == "sandbox") {
             $this->assertStringStartsWith("https://sandbox-payment.fiuu.com", $url);
         } else {
             $this->assertStringStartsWith("https://pay.merchant.razer.com", $url);
@@ -92,7 +92,7 @@ final class PaymentTest extends TestCase
     {
         $amount = number_format(self::$amount*1, 2, '.', '');
         writelog("Amount: $amount");
-        $calculatedVcode = md5($amount . env('RMS_MERCHANT_ID') . self::$orderid . env('RMS_VERIFY_KEY'));
+        $calculatedVcode = md5($amount . env('FIUU_MERCHANT_ID') . self::$orderid . env('FIUU_VERIFY_KEY'));
         writelog("Calculated Vcode - $calculatedVcode");
         // check url contains valid vcode
         $this->assertStringContainsString("&vcode=$calculatedVcode", $url);


### PR DESCRIPTION
## Summary by Sourcery

Migrate the PHP payment library from Razer Merchant Services to Fiuu by renaming namespaces, updating package metadata and environment variables, switching endpoints to Fiuu URLs, and adjusting tests and examples accordingly.

Enhancements:
- Rename core namespace and class references from RazerMerchantServices to Fiuu and update environment variable prefixes from RMS_ to FIUU_
- Update payment endpoint URLs in the Payment class to point to Fiuu domains based on environment
- Refresh Laravel example code to instantiate and use Fiuu\Payment instead of RazerMerchantServices

Build:
- Revise composer.json package name, description, keywords, homepage, repository URL, and PSR-4 autoload mapping to Fiuu

Tests:
- Modify PHPUnit tests to reference Fiuu\Payment, new env var names, and assert against updated Fiuu endpoint URLs